### PR TITLE
Fix getIterator() return type deprecation

### DIFF
--- a/Operations/ScaffoldFileCollection.php
+++ b/Operations/ScaffoldFileCollection.php
@@ -115,7 +115,7 @@ class ScaffoldFileCollection implements \IteratorAggregate {
   /**
    * {@inheritdoc}
    */
-  public function getIterator() {
+  public function getIterator(): \Traversable {
     return new \ArrayIterator($this->scaffoldFilesByProject);
   }
 


### PR DESCRIPTION
This PR resolves a deprecation notice that occurs when using Composer to create a new Mautic project with PHP 8.1 or newer. The deprecation warning arises due to a mismatch in the return type declaration of the `getIterator()` method in the `ScaffoldFileCollection` class.

Updated `ScaffoldFileCollection::getIterator()` to explicitly declare its return type as `\Traversable`, ensuring compliance with the `IteratorAggregate` interface.

The deprecation notice appears when running:
```bash
composer create-project mautic/recommended-project:^6.0-dev some-dir --no-interaction
```

```
Deprecation Notice: Return type of Mautic\Composer\Plugin\Scaffold\Operations\ScaffoldFileCollection::getIterator() should either be compatible with IteratorAggregate::getIterator(): Traversable, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in /home/martin/mautic-recommended-project/some-dir/vendor/mautic/core-composer-scaffold/Operations/ScaffoldFileCollection.php:118
```

![image](https://github.com/user-attachments/assets/4664beda-48b4-4310-bcdd-524113731fc1)